### PR TITLE
Money bundles wouldn't get the outline

### DIFF
--- a/Gold&Money&Cocaine&Weapon_Outlines_Highlight/units/payday2/equipment/ind_interactable_hardcase_loot/ind_interactable_hardcase_loot_money.material_config
+++ b/Gold&Money&Cocaine&Weapon_Outlines_Highlight/units/payday2/equipment/ind_interactable_hardcase_loot/ind_interactable_hardcase_loot_money.material_config
@@ -1,5 +1,5 @@
 <materials version="3">
-    <material name="mtr_money" unique="true" render_template="generic:CONTOUR:DIFFUSE_TEXTURE:DOUBLE_SIDED:NORMALMAP" version="2">
+    <material name="mtr_money" unique="true" render_template="generic:CONTOUR:DIFFUSE_TEXTURE:NORMALMAP" version="2">
         <diffuse_texture file="units/payday2/equipment/ind_interactable_hardcase_loot/money_df"/>
         <bump_normal_texture file="units/payday2/equipment/ind_interactable_hardcase_loot/money_nm"/>
 		<variable name="contour_color" value="1 1 1" type="vector3"/>


### PR DESCRIPTION
I still can't explain why, but removing this ":DOUBLE_SIDED" parameter made it actually work for me.
I tested it on Shadow Raid.